### PR TITLE
fix ExecutionManager test to avoid race condition

### DIFF
--- a/execution_manager.go
+++ b/execution_manager.go
@@ -89,10 +89,10 @@ func (r *ExecutionManager) ExecuteProcesses() {
 	r.logInfof("start all processes execution")
 	defer r.logInfof("all processes execution stopped")
 	r.wg.Add(len(r.processes))
-	go r.listenSignals()
 	for _, process := range r.processes {
 		go r.run(process)
 	}
+	go r.listenSignals()
 	r.wg.Wait()
 }
 

--- a/execution_manager_panic_test.go
+++ b/execution_manager_panic_test.go
@@ -47,7 +47,7 @@ type panicProcess struct {
 	isExitByContext bool
 }
 
-func (r panicProcess) isRunCalledCh() <-chan struct{} { return r.runCalledCh }
+func (r *panicProcess) isRunCalledCh() <-chan struct{} { return r.runCalledCh }
 
 func (r panicProcess) Name() string { return r.name }
 
@@ -60,7 +60,6 @@ func (r *panicProcess) Run(ctx context.Context) {
 		panic("AAA!!! Aliens!!! Not again!!!")
 	case <-ctx.Done():
 		r.isExitByContext = true
-		break
 	case <-time.After(maxProcessDuration):
 		break
 	}

--- a/execution_manager_test.go
+++ b/execution_manager_test.go
@@ -52,7 +52,7 @@ type someProcess struct {
 	isExitByContext bool
 }
 
-func (r someProcess) isRunCalledCh() <-chan struct{} { return r.runCalledCh }
+func (r *someProcess) isRunCalledCh() <-chan struct{} { return r.runCalledCh }
 
 func (r someProcess) Name() string { return r.name }
 
@@ -62,10 +62,8 @@ func (r *someProcess) Run(ctx context.Context) {
 	select {
 	case <-r.manualStopCh:
 		r.isExitByCommand = true
-		break
 	case <-ctx.Done():
 		r.isExitByContext = true
-		break
 	case <-time.After(maxProcessDuration):
 		break
 	}


### PR DESCRIPTION
testing process should use ptr receiver to avoid of race when working with signals